### PR TITLE
Cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -384,7 +384,7 @@ add_definitions(-DBUILDING_URBI_SDK -DBUILDING_URBI_MODULE)
 # but this one needs to be correct, because DEPENDS does not honor OUTPUT_NAME
 qi_create_lib(uobject
   SHARED
-  SUBFOLDER gostai/engine
+  SUBFOLDER /gostai/engine
   DEPENDS port sched serialize BOOST BOOST_REGEX BOOST_SIGNALS BOOST_FILESYSTEM BOOST_DATE_TIME  BOOST_SYSTEM BOOST_THREAD
   SRC ${UCO_SRC} ${UOBJECT_PLUGIN_SRC}
 )

--- a/sdk-remote/CMakeLists.txt
+++ b/sdk-remote/CMakeLists.txt
@@ -88,7 +88,7 @@ set(UOBJECT_REMOTE_SRC
 )
 
 qi_create_lib(uobject-remote
-  SUBFOLDER gostai/remote
+  SUBFOLDER /gostai/remote
   SHARED
   DEPENDS port serialize ${JPEG_PACKAGE} BOOST BOOST_REGEX BOOST_DATE_TIME  BOOST_SYSTEM BOOST_THREAD
   SRC ${COMMON_SRC} ${UOBJECT_REMOTE_SRC} ${URBI_SRC}

--- a/sdk-remote/CMakeLists.txt
+++ b/sdk-remote/CMakeLists.txt
@@ -96,7 +96,7 @@ qi_create_lib(uobject-remote
 set_target_properties(uobject-remote
   PROPERTIES
      OUTPUT_NAME uobject
-     INSTALL_NAME_DIR "@executable_path/../lib/gostai/engine"
+     INSTALL_NAME_DIR "@executable_path/../lib/gostai/remote"
      COMPILE_FLAGS -DBUILDING_URBI_SDK)
 
 if (NOT APPLE AND NOT WIN32)

--- a/sdk-remote/src/uobjects/CMakeLists.txt
+++ b/sdk-remote/src/uobjects/CMakeLists.txt
@@ -2,7 +2,7 @@ function(uobject name path)
   # all uobjects can link with any of the uobjects
   # except lib-urbi which uses liburbi
   qi_create_lib( ${name}
-    SHARED
+    MODULE
     SUBFOLDER gostai/uobjects/${path}
     SRC ${ARGN}
   )


### PR DESCRIPTION
 Generated `uobject-config.cmake` and `uobject-remote-config.cmake` declare `UOBJECT_LIBRARIES` and `UOBJECT-REMOTE_LIBRARIES` with wrong paths to libraries, e.g.:
```cmake
set(UOBJECT-REMOTE_LIBRARIES
  "debug;${ROOT_DIR}/libgostai/remote/uobject_d.lib;optimized;${ROOT_DIR}/libgostai/remote/uobject.lib"
  CACHE STRING "" FORCE)
```
Instead **`libgostai`**, should be **`lib/gostai`**.

Second commit changes UObject library types from `SHARED` to `MODULE`. It's matter on Windows, where for `SHARED` the linking `*.lib` file is generated. However, UObjects don't need these files.