### PR TITLE
Static build, embed .u files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,94 @@ find_program(_python_executable
     qi_error("needs python executable in PATH")
   endif()
 
+
 include_directories(${Boost_INCLUDES})
 add_definitions(-DBOOST_ALL_NO_LIBS)
 add_definitions(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
+
+if (WITH_EMBED)
+set(U_FILES
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/pubsub.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/require-file.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/stack-frame.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/trajectory-generator.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/code.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/logger.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/string.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/float.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/event.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/boolean.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/directory.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/traceable.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/local.mk
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/process.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/package-info/urbi.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/package-info/libport.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/monitoring.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/comparable.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/group.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/singleton.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/call-message.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/tuple.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/dataflow.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/container.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/lobby.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/tag.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/formatter.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/pattern.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/component.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/object.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/python.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/urbi.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/file.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/run-test.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/job.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/lazy.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/test-suite.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/loadable.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/semaphore.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/system.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/path.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/dictionary.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/math.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/naming-standard.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/duration.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/weak-pointer.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/utags.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/enumeration.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/timeout.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/global.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/vector.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/regexp.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/input-stream.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/list.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/range-iterable.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/package-info.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/updatehook-stack.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/mutex.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/orderable.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/channel.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/profile.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/uobject.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/control.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/kernel1.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/platform.u.in
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/socket.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/date.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/binary.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/nil.u
+${CMAKE_CURRENT_SOURCE_DIR}/share:urbi/exception.u
+${CMAKE_CURRENT_BINARY_DIR}/share:urbi/platform.u
+)
+  set(EMBED_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/src/kernel/embed.hh)
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/src/kernel/embed.hh
+    COMMAND ${_python_executable} ${CMAKE_CURRENT_SOURCE_DIR}/dev/embed.py ${CMAKE_CURRENT_BINARY_DIR}/src/kernel/embed.hh none ${U_FILES}
+   DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/share/urbi/platform.u
+   )
+  add_definitions(-DURBI_WITH_EMBED)
+else()
+  set(EMBED_SOURCES "")
+endif()
 
 add_subdirectory(sdk-remote)
 
@@ -392,9 +477,10 @@ add_definitions(-DBUILDING_URBI_SDK -DBUILDING_URBI_MODULE)
 
 # uobject-remote is renamed as uobject using a set_target_properties
 # but this one needs to be correct, because DEPENDS does not honor OUTPUT_NAME
+
 add_library(uobject
   ${LIB_MODE}
-  ${UCO_SRC} ${UOBJECT_PLUGIN_SRC}
+  ${UCO_SRC} ${UOBJECT_PLUGIN_SRC} ${EMBED_SOURCES}
 )
 target_link_libraries(uobject
   port sched serialize Boost::filesystem Boost::date_time Boost::system Boost::thread Boost::regex

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,13 @@ project(kernel)
 
 add_subdirectory(libport)
 
+if (STATIC_BUILD)
+  set(LIB_MODE STATIC)
+  add_definitions(-DSTATIC_BUILD=1)
+else()
+  set(LIB_MODE SHARED)
+endif()
+
 find_package(Boost REQUIRED COMPONENTS chrono thread system filesystem date_time regex)
 #find python
 find_program(_python_executable
@@ -386,7 +393,7 @@ add_definitions(-DBUILDING_URBI_SDK -DBUILDING_URBI_MODULE)
 # uobject-remote is renamed as uobject using a set_target_properties
 # but this one needs to be correct, because DEPENDS does not honor OUTPUT_NAME
 add_library(uobject
-  SHARED
+  ${LIB_MODE}
   ${UCO_SRC} ${UOBJECT_PLUGIN_SRC}
 )
 target_link_libraries(uobject
@@ -402,7 +409,13 @@ set_target_properties(uobject
 
 install(TARGETS uobject DESTINATION lib/gostai/engine)
 
-
+add_executable(urbiscript
+  sdk-remote/src/liburbi/urbi.cc  $<TARGET_OBJECTS:uobject>
+  )
+target_link_libraries(urbiscript 
+  port sched serialize Boost::filesystem Boost::date_time Boost::system Boost::thread Boost::regex
+  )
+install(TARGETS urbiscript)
 # Add a simple test:
 enable_testing()
 

--- a/dev/embed.py
+++ b/dev/embed.py
@@ -1,0 +1,43 @@
+#! /usr/bin/env python3
+
+""" Embed files in a C++ header
+
+    First argument is output file
+    Second argument is base path
+    Remaining arguments can be remain_path or base_path:remain_path.
+    The second form overrides default base path
+
+    Creates a unordered_map<string,string> 'embeded_files'
+    with key remain_path and value the content of the file
+"""
+import sys
+import os
+output = sys.argv[1]
+base_path = sys.argv[2]
+inputs = sys.argv[3:]
+
+
+with open(output, 'w') as out:
+    out.write("""
+#include <string>
+#include <unordered_map>
+
+
+std::unordered_map<std::string, std::string> embeded_files = {
+""")
+    for f in inputs:
+        bpart = base_path
+        fpart = f
+        if f.index(':')!=-1:
+            fb = f.split(':')
+            if len(fb) == 3:
+                bpart = fb[0] + ':' + fb[1]
+                fpart = fb[2]
+            else:
+                bpart = fb[0]
+                fpart = fb[1]
+        with open(os.path.join(bpart, fpart), 'r') as inp:
+            data = inp.read()
+            vals = ','.join(map(lambda x: str(ord(x)), data))
+            out.write('{"' + fpart + '", {' + vals + '}},\n')
+    out.write('};')

--- a/sdk-remote/CMakeLists.txt
+++ b/sdk-remote/CMakeLists.txt
@@ -4,6 +4,7 @@ if (CMAKE_BUILD_TYPE STREQUAL Debug)
   add_definitions(-DURBI_COMPILATION_MODE_DEBUG)
 endif()
 
+
 if(NOT STATIC_BUILD)
 add_executable(urbi-launch
     src/bin/urbi-launch.cc
@@ -23,6 +24,7 @@ endif()
 
 install(TARGETS urbi-launch)
 endif()
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../libport/include)

--- a/sdk-remote/CMakeLists.txt
+++ b/sdk-remote/CMakeLists.txt
@@ -4,6 +4,7 @@ if (CMAKE_BUILD_TYPE STREQUAL Debug)
   add_definitions(-DURBI_COMPILATION_MODE_DEBUG)
 endif()
 
+if(NOT STATIC_BUILD)
 add_executable(urbi-launch
     src/bin/urbi-launch.cc
     src/liburbi/urbi-launch.cc
@@ -21,7 +22,7 @@ if (NOT APPLE AND NOT WIN32)
 endif()
 
 install(TARGETS urbi-launch)
-
+endif()
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../libport/include)
@@ -97,7 +98,7 @@ set(UOBJECT_REMOTE_SRC
 )
 
 add_library(uobject-remote
-  SHARED
+  ${LIB_MODE}
   ${COMMON_SRC} ${UOBJECT_REMOTE_SRC} ${URBI_SRC}
 )
 target_link_libraries(uobject-remote
@@ -119,7 +120,7 @@ install(TARGETS uobject-remote DESTINATION lib/gostai/remote)
 #uobject-remote is instaled at a custom location.
 #So we still need a liburbi for programs wanting to link with it
 add_library(urbi
-  SHARED
+  ${LIB_MODE}
   ${COMMON_SRC} ${URBI_SRC}
 )
 target_link_libraries(urbi
@@ -135,8 +136,9 @@ endif()
 
 install(TARGETS urbi)
 
-
+if (NOT STATIC_BUILD)
 add_subdirectory(src/examples)
+endif()
 add_subdirectory(include)
 
 # Scripts

--- a/sdk-remote/src/liburbi/urbi.cc
+++ b/sdk-remote/src/liburbi/urbi.cc
@@ -1,0 +1,5 @@
+#include <urbi/umain.hh>
+
+
+
+UMAIN();

--- a/src/object/register.cc
+++ b/src/object/register.cc
@@ -68,6 +68,11 @@ namespace urbi
 {
   namespace object
   {
+    // Hack to avoid requiring whole-archive when static linking.
+    int dummy_register_function()
+    {
+      return 5142;
+    }
     URBI_CXX_OBJECT_REGISTER(Executable);
     URBI_CXX_OBJECT_REGISTER(Primitive);
     URBI_CXX_OBJECT_REGISTER(Slot);

--- a/src/object/root-classes.cc
+++ b/src/object/root-classes.cc
@@ -96,6 +96,8 @@ namespace urbi
       return args.front();
     }
 
+    int dummy_register_function();
+
     /// Initialize the root classes.  There are some dependency issues.
     /// For instance, String is a clone of Object, but Object.type is a
     /// String.  So we need to control the initialization sequence.
@@ -104,6 +106,7 @@ namespace urbi
     {
       if (root_classes_initialized)
         return;
+      dummy_register_function();
       root_classes_initialized = true;
 
       // The construction of the primitive classes goes in several

--- a/src/object/system.cc
+++ b/src/object/system.cc
@@ -275,10 +275,6 @@ namespace urbi
     system_loadFile(rObject, const std::string& filename, rObject self)
     {
       GD_FPUSH_TRACE("Load file: %s", filename);
-#if defined ENABLE_SERIALIZATION
-      if (!libport::path(filename).exists())
-        runner::raise_urbi(SYMBOL(FileNotFound), to_urbi(filename));
-#endif
       try
       {
         return execute_parsed(parser::parse_file(filename), self);


### PR DESCRIPTION
Produces a fully independent executable "urbiscript".
Note: to link with the libuobject.a you need whole-archive linker flag.